### PR TITLE
Fix missing space in heading

### DIFF
--- a/_posts/2015-11-18-ltspice-tube-screamer.md
+++ b/_posts/2015-11-18-ltspice-tube-screamer.md
@@ -35,7 +35,7 @@ That name may not be terribly familiar to you, but you'll likely recognize more 
 
 That's some bullshit, and IT ENDS TODAY.
 
-##The Circuit
+## The Circuit
 
 <div align="center">
 <img src="/assets/tube_screamer_circuit.png"/>


### PR DESCRIPTION
Fixes a 2nd level header that lacked a space so it rendered as `##The Circuit`.  

And yes, posting a PR against a blog post from 2015 is a absolutely a sign of too much time on one's hands. :)